### PR TITLE
Prepend path separator to GOROOT prefix when checking for stdlib packages

### DIFF
--- a/licenses/library.go
+++ b/licenses/library.go
@@ -201,5 +201,5 @@ func isStdLib(pkg *packages.Package) bool {
 	if len(pkg.GoFiles) == 0 {
 		return false
 	}
-	return strings.HasPrefix(pkg.GoFiles[0], build.Default.GOROOT)
+	return strings.HasPrefix(pkg.GoFiles[0], build.Default.GOROOT + string(filepath.Separator))
 }


### PR DESCRIPTION
previously, this code was simply checking if the `build.Default.GOROOT` was a prefix of the target package path to see if the package was from the stdlib. this was failing for me, as the default GOROOT `/usr/local/go` was being used (since I don't have one set), but all of my packages lived under `/usr/local/google/...`.

sadly, there's no better solution in the `filepath` package to check if a path is nested under another path.