### PR TITLE
Detect licenses regardless of their file extension

### DIFF
--- a/licenses/classifier_test.go
+++ b/licenses/classifier_test.go
@@ -64,6 +64,13 @@ func TestIdentify(t *testing.T) {
 			wantType:    Notice,
 		},
 		{
+			desc:        "MIT license",
+			file:        "testdata/MIT/LICENSE.MIT",
+			confidence:  1,
+			wantLicense: "MIT",
+			wantType:    Notice,
+		},
+		{
 			desc:       "non-existent file",
 			file:       "non-existent-file",
 			confidence: 1,

--- a/licenses/find.go
+++ b/licenses/find.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	licenseRegexp = regexp.MustCompile(`^(LICEN(S|C)E|COPYING|README|NOTICE)(\.(txt|md))?$`)
+	licenseRegexp = regexp.MustCompile(`^(LICEN(S|C)E|COPYING|README|NOTICE)(\..+)?$`)
 	srcDirRegexps = func() []*regexp.Regexp {
 		var rs []*regexp.Regexp
 		for _, s := range build.Default.SrcDirs() {

--- a/licenses/find_test.go
+++ b/licenses/find_test.go
@@ -29,6 +29,7 @@ func TestFind(t *testing.T) {
 	classifier := classifierStub{
 		licenseNames: map[string]string{
 			"testdata/LICENSE":           "foo",
+			"testdata/MIT/LICENSE.MIT":   "MIT",
 			"testdata/licence/LICENCE":   "foo",
 			"testdata/copying/COPYING":   "foo",
 			"testdata/notice/NOTICE.txt": "foo",
@@ -36,6 +37,7 @@ func TestFind(t *testing.T) {
 		},
 		licenseTypes: map[string]Type{
 			"testdata/LICENSE":           Notice,
+			"testdata/MIT/LICENSE.MIT":   Notice,
 			"testdata/licence/LICENCE":   Notice,
 			"testdata/copying/COPYING":   Notice,
 			"testdata/notice/NOTICE.txt": Notice,
@@ -57,6 +59,11 @@ func TestFind(t *testing.T) {
 			desc:            "licenCe",
 			dir:             "testdata/licence",
 			wantLicensePath: filepath.Join(wd, "testdata/licence/LICENCE"),
+		},
+		{
+			desc:            "LICENSE.MIT",
+			dir:             "testdata/MIT",
+			wantLicensePath: filepath.Join(wd, "testdata/MIT/LICENSE.MIT"),
 		},
 		{
 			desc:            "COPYING",

--- a/licenses/testdata/MIT/LICENSE.MIT
+++ b/licenses/testdata/MIT/LICENSE.MIT
@@ -1,0 +1,7 @@
+Copyright 2020 Google Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Previously, only files with no extension or either ".md" or ".txt" extensions were recognised.

This fixes https://github.com/google/go-licenses/issues/15.