### PR TITLE
Do not copy code for Reciprocal licenses

### DIFF
--- a/save.go
+++ b/save.go
@@ -94,13 +94,13 @@ func saveMain(_ *cobra.Command, args []string) error {
 			return err
 		}
 		switch licenseType {
-		case licenses.Restricted, licenses.Reciprocal:
+		case licenses.Restricted:
 			// Copy the entire source directory for the library.
 			libDir := filepath.Dir(lib.LicensePath)
 			if err := copySrc(libDir, libSaveDir); err != nil {
 				return err
 			}
-		case licenses.Notice, licenses.Permissive, licenses.Unencumbered:
+		case licenses.Notice, licenses.Permissive, licenses.Unencumbered, licenses.Reciprocal:
 			// Just copy the license and copyright notice.
 			if err := copyNotices(lib.LicensePath, libSaveDir); err != nil {
 				return err


### PR DESCRIPTION
According to the description:
```
// Reciprocal licenses allow usage of software made available under such
// licenses freely in *unmodified* form. If the third-party source code is
// modified in any way these modifications to the original third-party
// source code must be made available.
```

For software that uses `Reciprocal` licenses, we don't need to copy the source directory as long as the code is unmodified. As normally users use third-party tools to vendor the dependencies, it seems to be overly cautious to always copy source code for Reciprocal licenses.