### PR TITLE
Add case insensitivity to regex

### DIFF
--- a/licenses/find.go
+++ b/licenses/find.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	licenseRegexp = regexp.MustCompile(`^(LICEN(S|C)E|COPYING|README|NOTICE)(\.(txt|md))?$`)
+	licenseRegexp = regexp.MustCompile(`^(?i)(LICEN(S|C)E|COPYING|README|NOTICE)(\.(txt|md))?$`)
 	srcDirRegexps = func() []*regexp.Regexp {
 		var rs []*regexp.Regexp
 		for _, s := range build.Default.SrcDirs() {


### PR DESCRIPTION
Adding case insensitivity to the regex covers more cases where the repository has named their LICENSES, COPYING and others with non standard names such as Licenses or licenses.

This is to catch cases which go-licenses is unable to such as https://github.com/kr/text/blob/main/License