### PR TITLE
Fix save file permissions.

### DIFF
--- a/save.go
+++ b/save.go
@@ -122,7 +122,7 @@ func copySrc(src, dest string) error {
 		Skip: func(src string) (bool, error) {
 			return strings.HasSuffix(src, ".git"), nil
 		},
-		AddPermission: 0700,
+		AddPermission: 0600,
 	}
 	if err := copy.Copy(src, dest, opt); err != nil {
 		return err


### PR DESCRIPTION
This was supposed to be set as 600 in
https://github.com/google/go-licenses/pull/65,
but was accidentally merged with 700.