### PR TITLE
Set permission of copied files to 0600

### DIFF
--- a/save.go
+++ b/save.go
@@ -122,7 +122,7 @@ func copySrc(src, dest string) error {
 		Skip: func(src string) (bool, error) {
 			return strings.HasSuffix(src, ".git"), nil
 		},
-		AddPermission: 0700,
+		AddPermission: 0600,
 	}
 	if err := copy.Copy(src, dest, opt); err != nil {
 		return err


### PR DESCRIPTION
As requested in https://github.com/google/go-licenses/pull/65/commits/1d265c9745733512abc491a0c2b1442ec8c518b3#r650031429.

Currently, all files are executable, which I believe wasn't the original intention.