### PR TITLE
fix:  make go-licenses work better with the embed package

### DIFF
--- a/save.go
+++ b/save.go
@@ -61,6 +61,17 @@ func init() {
 }
 
 func saveMain(_ *cobra.Command, args []string) error {
+
+	classifier, err := licenses.NewClassifier(confidenceThreshold)
+	if err != nil {
+		return err
+	}
+
+	libs, err := licenses.Libraries(context.Background(), classifier, args...)
+	if err != nil {
+		return err
+	}
+
 	if overwriteSavePath {
 		if err := os.RemoveAll(savePath); err != nil {
 			return err
@@ -76,15 +87,6 @@ func saveMain(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	classifier, err := licenses.NewClassifier(confidenceThreshold)
-	if err != nil {
-		return err
-	}
-
-	libs, err := licenses.Libraries(context.Background(), classifier, args...)
-	if err != nil {
-		return err
-	}
 	libsWithBadLicenses := make(map[licenses.Type][]*licenses.Library)
 	for _, lib := range libs {
 		libSaveDir := filepath.Join(savePath, unvendor(lib.Name()))


### PR DESCRIPTION
As per discussion in #79 , `go-licenses` with the `--force` option currently deletes the output directory before loading the packages. If the output directory is embedded in the application with the embed.FS package, this results in compilation (and by extension, loading) to fail, which in turn causes `go-licenses` to fail.

This PR swaps the order of operations (as recommended by @wlynch) so that the output directory is deleted _after_ go-licenses has already collected the licenses.

The use case for this is to embed all of the licenses of a golang application's dependencies in the golang application itself, so that they can later be retrieved. For example, by a `--license` CLI argument or something similar.