### PR TITLE
feat!(v2): use go modules info

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/csv"
 	"os"
-	"strings"
 
 	"github.com/golang/glog"
 	"github.com/google/go-licenses/licenses"
@@ -56,41 +55,12 @@ func csvMain(_ *cobra.Command, args []string) error {
 	}
 	for _, lib := range libs {
 		licenseURL := "Unknown"
-		licenseName := "Unknown"
-		if lib.LicensePath != "" {
-			// Find a URL for the license file, based on the URL of a remote for the Git repository.
-			var errs []string
-			repo, err := licenses.FindGitRepo(lib.LicensePath)
-			if err != nil {
-				// Can't find Git repo (possibly a Go Module?) - derive URL from lib name instead.
-				lURL, err := lib.FileURL(lib.LicensePath)
-				if err != nil {
-					errs = append(errs, err.Error())
-				} else {
-					licenseURL = lURL.String()
-				}
-			} else {
-				for _, remote := range gitRemotes {
-					url, err := repo.FileURL(lib.LicensePath, remote)
-					if err != nil {
-						errs = append(errs, err.Error())
-						continue
-					}
-					licenseURL = url.String()
-					break
-				}
-			}
-			if licenseURL == "Unknown" {
-				glog.Errorf("Error discovering URL for %q:\n- %s", lib.LicensePath, strings.Join(errs, "\n- "))
-			}
-			licenseName, _, err = classifier.Identify(lib.LicensePath)
-			if err != nil {
-				glog.Errorf("Error identifying license in %q: %v", lib.LicensePath, err)
-				licenseName = "Unknown"
-			}
+		licenseName, _, err := classifier.Identify(lib.LicensePath)
+		if err != nil {
+			glog.Errorf("Error identifying license in %q: %v", lib.LicensePath, err)
+			licenseName = "Unknown"
 		}
-		// Remove the "*/vendor/" prefix from the library name for conciseness.
-		if err := writer.Write([]string{unvendor(lib.Name()), licenseURL, licenseName}); err != nil {
+		if err := writer.Write([]string{lib.Name(), licenseURL, licenseName}); err != nil {
 			return err
 		}
 	}

--- a/internal/third_party/pkgsite/README.md
+++ b/internal/third_party/pkgsite/README.md
@@ -16,3 +16,4 @@ Local modifications:
   pkgsite/internal/version to avoid other dependencies.
 - For pkgsite/internal/source, switched to use go log package, because glog conflicts with a test
   dependency that also defines the "v" flag.
+- Add a SetCommit method to type ModuleInfo in ./source/source_patch.go, more rationale explained in the method's comments.

--- a/internal/third_party/pkgsite/source/source_patch.go
+++ b/internal/third_party/pkgsite/source/source_patch.go
@@ -1,0 +1,33 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+// This file includes all local additions to source package for google/go-licenses use-cases.
+
+// SetCommit overrides commit to a specified commit. Usually, you should pass your version to
+// ModuleInfo(). However, when you do not know the version and just wants a link that points to
+// a known commit/branch/tag. You can use this method to directly override the commit like
+// info.SetCommit("master").
+//
+// Note this is different from directly passing "master" as version to ModuleInfo(), because for
+// modules not at the root of a repo, there are conventions that add a module's relative dir in
+// front of the version as the actual git tag. For example, for a sub module at ./submod whose
+// version is v1.0.1, the actual git tag should be submod/v1.0.1.
+func (i *Info) SetCommit(commit string) {
+	if i == nil {
+		return
+	}
+	i.commit = commit
+}

--- a/licenses/find.go
+++ b/licenses/find.go
@@ -16,30 +16,34 @@ package licenses
 
 import (
 	"fmt"
-	"go/build"
 	"io/ioutil"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 var (
 	licenseRegexp = regexp.MustCompile(`^(?i)(LICEN(S|C)E|COPYING|README|NOTICE).*$`)
-	srcDirRegexps = func() []*regexp.Regexp {
-		var rs []*regexp.Regexp
-		for _, s := range build.Default.SrcDirs() {
-			rs = append(rs, regexp.MustCompile("^"+regexp.QuoteMeta(s)+"$"))
-		}
-		return rs
-	}()
-	vendorRegexp = regexp.MustCompile(`.+/vendor(/)?$`)
 )
 
 // Find returns the file path of the license for this package.
-func Find(dir string, classifier Classifier) (string, error) {
-	var stopAt []*regexp.Regexp
-	stopAt = append(stopAt, srcDirRegexps...)
-	stopAt = append(stopAt, vendorRegexp)
-	return findUpwards(dir, licenseRegexp, stopAt, func(path string) bool {
+//
+// dir is path of the directory where we want to find a license.
+// rootDir is path of the module containing this package. Find will not search out of the
+// rootDir.
+func Find(dir string, rootDir string, classifier Classifier) (string, error) {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	rootDir, err = filepath.Abs(rootDir)
+	if err != nil {
+		return "", err
+	}
+	if !strings.HasPrefix(dir, rootDir) {
+		return "", fmt.Errorf("licenses.Find: rootDir %s should contain dir %s", rootDir, dir)
+	}
+	return findUpwards(dir, licenseRegexp, rootDir, func(path string) bool {
 		// TODO(RJPercival): Return license details
 		if _, _, err := classifier.Identify(path); err != nil {
 			return false
@@ -48,15 +52,15 @@ func Find(dir string, classifier Classifier) (string, error) {
 	})
 }
 
-func findUpwards(dir string, r *regexp.Regexp, stopAt []*regexp.Regexp, predicate func(path string) bool) (string, error) {
+func findUpwards(dir string, r *regexp.Regexp, stopAt string, predicate func(path string) bool) (string, error) {
 	// Dir must be made absolute for reliable matching with stopAt regexps
 	dir, err := filepath.Abs(dir)
 	if err != nil {
 		return "", err
 	}
 	start := dir
-	// Stop once dir matches a stopAt regexp or dir is the filesystem root
-	for !matchAny(stopAt, dir) {
+	// Stop once we go out of the stopAt dir.
+	for strings.HasPrefix(dir, stopAt) {
 		dirContents, err := ioutil.ReadDir(dir)
 		if err != nil {
 			return "", err
@@ -78,13 +82,4 @@ func findUpwards(dir string, r *regexp.Regexp, stopAt []*regexp.Regexp, predicat
 		dir = parent
 	}
 	return "", fmt.Errorf("no file/directory matching regexp %q found for %s", r, start)
-}
-
-func matchAny(patterns []*regexp.Regexp, s string) bool {
-	for _, p := range patterns {
-		if p.MatchString(s) {
-			return true
-		}
-	}
-	return false
 }

--- a/licenses/find_test.go
+++ b/licenses/find_test.go
@@ -101,7 +101,7 @@ func TestFind(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			licensePath, err := Find(test.dir, classifier)
+			licensePath, err := Find(test.dir, "./testdata", classifier)
 			if err != nil || licensePath != test.wantLicensePath {
 				t.Fatalf("Find(%q) = (%#v, %q), want (%q, nil)", test.dir, licensePath, err, test.wantLicensePath)
 			}

--- a/licenses/git.go
+++ b/licenses/git.go
@@ -46,7 +46,7 @@ type GitRepo struct {
 // FindGitRepo finds the Git repository that contains the specified filePath
 // by searching upwards through the directory tree for a ".git" directory.
 func FindGitRepo(filePath string) (*GitRepo, error) {
-	path, err := findUpwards(filepath.Dir(filePath), gitRegexp, srcDirRegexps, nil)
+	path, err := findUpwards(filepath.Dir(filePath), gitRegexp, "/", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/licenses/git.go
+++ b/licenses/git.go
@@ -46,6 +46,9 @@ type GitRepo struct {
 // FindGitRepo finds the Git repository that contains the specified filePath
 // by searching upwards through the directory tree for a ".git" directory.
 func FindGitRepo(filePath string) (*GitRepo, error) {
+	// TODO(Bobgy): the "/" is used just to fix the test. git.go is not
+	// currently used, but I plan to bring it back to detect version of the
+	// main module in following up PRs.
 	path, err := findUpwards(filepath.Dir(filePath), gitRegexp, "/", nil)
 	if err != nil {
 		return nil, err

--- a/licenses/library.go
+++ b/licenses/library.go
@@ -140,6 +140,19 @@ func Libraries(ctx context.Context, classifier Classifier, importPaths ...string
 				glog.Warningf("module %s does not have dir and it's not vendored, cannot discover the license URL. Report to go-licenses developer if you see this.", lib.module.Path)
 			} else {
 				// This is vendored. Handle this known special case.
+
+				// Extra note why we identify a vendored package like this.
+				//
+				// For a normal package:
+				// * if it's not in a module, lib.module == nil
+				// * if it's in a module, lib.module.Dir != ""
+				// Only vendored modules will have lib.module != nil && lib.module.Path != "" && lib.module.Dir == "" as far as I know.
+				// So the if condition above is already very strict for vendored packages.
+				// On top of it, we checked the lib.LicensePath contains a vendor folder in it.
+				// So it's rare to have a false positive for both conditions at the same time, although it may happen in theory.
+				//
+				// These assumptions may change in the future,
+				// so we need to keep this updated with go tooling changes.
 				parentModDir := splits[0]
 				var parentPkg *packages.Package
 				for _, rootPkg := range rootPkgs {

--- a/licenses/library_test.go
+++ b/licenses/library_test.go
@@ -199,7 +199,7 @@ func TestLibraryFileURL(t *testing.T) {
 			wantURL: "https://example.com/user/project/blob/v1.2.3/foo/README.md",
 		},
 		{
-			desc: "Library without version defaults to master branch",
+			desc: "Library without version defaults to remote HEAD",
 			lib: &Library{
 				Packages: []string{
 					"github.com/google/trillian",
@@ -212,7 +212,7 @@ func TestLibraryFileURL(t *testing.T) {
 				},
 			},
 			path:    "/go/src/github.com/google/trillian/foo/README.md",
-			wantURL: "https://github.com/google/trillian/blob/master/foo/README.md",
+			wantURL: "https://github.com/google/trillian/blob/HEAD/foo/README.md",
 		},
 		{
 			desc: "Library on k8s.io",

--- a/licenses/library_test.go
+++ b/licenses/library_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"golang.org/x/tools/go/packages"
 )
 
 func TestLibraries(t *testing.T) {
@@ -155,7 +154,7 @@ func TestLibraryFileURL(t *testing.T) {
 					"github.com/google/trillian/crypto",
 				},
 				LicensePath: "/go/src/github.com/google/trillian/LICENSE",
-				Module: &packages.Module{
+				module: &Module{
 					Path:    "github.com/google/trillian",
 					Dir:     "/go/src/github.com/google/trillian",
 					Version: "v1.2.3",
@@ -172,7 +171,7 @@ func TestLibraryFileURL(t *testing.T) {
 					"bitbucket.org/user/project/pkg2",
 				},
 				LicensePath: "/foo/bar/bitbucket.org/user/project/LICENSE",
-				Module: &packages.Module{
+				module: &Module{
 					Path:    "bitbucket.org/user/project",
 					Dir:     "/foo/bar/bitbucket.org/user/project",
 					Version: "v1.2.3",
@@ -189,7 +188,7 @@ func TestLibraryFileURL(t *testing.T) {
 					"example.com/user/project/pkg2",
 				},
 				LicensePath: "/foo/bar/example.com/user/project/LICENSE",
-				Module: &packages.Module{
+				module: &Module{
 					Path:    "example.com/user/project",
 					Dir:     "/foo/bar/example.com/user/project",
 					Version: "v1.2.3",
@@ -206,7 +205,7 @@ func TestLibraryFileURL(t *testing.T) {
 					"github.com/google/trillian/crypto",
 				},
 				LicensePath: "/go/src/github.com/google/trillian/LICENSE",
-				Module: &packages.Module{
+				module: &Module{
 					Path: "github.com/google/trillian",
 					Dir:  "/go/src/github.com/google/trillian",
 				},
@@ -221,7 +220,7 @@ func TestLibraryFileURL(t *testing.T) {
 					"k8s.io/api/core/v1",
 				},
 				LicensePath: "/go/modcache/k8s.io/api/LICENSE",
-				Module: &packages.Module{
+				module: &Module{
 					Path:    "k8s.io/api",
 					Dir:     "/go/modcache/k8s.io/api",
 					Version: "v0.23.1",

--- a/licenses/module.go
+++ b/licenses/module.go
@@ -1,0 +1,69 @@
+// Copyright 2022 Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package licenses
+
+import (
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// Module provides module information for a package.
+type Module struct {
+	// Differences from packages.Module:
+	// * Replace field is removed, it's only an implementation detail in this package.
+	//   If a module is replaced, we'll directly return the replaced module.
+	// * Version field +incompatible suffix is trimmed.
+	// * Main, ModuleError, Time, Indirect, GoMod, GoVersion fields are removed, because they are not used.
+	Path    string // module path
+	Version string // module version
+	Dir     string // directory holding files for this module, if any
+}
+
+func newModule(mod *packages.Module) *Module {
+	if mod == nil {
+		return nil
+	}
+	// Example of a module with replace directive: 	k8s.io/kubernetes => k8s.io/kubernetes v1.11.1
+	// {
+	//         "Path": "k8s.io/kubernetes",
+	//         "Version": "v0.17.9",
+	//         "Replace": {
+	//                 "Path": "k8s.io/kubernetes",
+	//                 "Version": "v1.11.1",
+	//                 "Time": "2018-07-17T04:20:29Z",
+	//                 "Dir": "/home/gongyuan_kubeflow_org/go/pkg/mod/k8s.io/kubernetes@v1.11.1",
+	//                 "GoMod": "/home/gongyuan_kubeflow_org/go/pkg/mod/cache/download/k8s.io/kubernetes/@v/v1.11.1.mod"
+	//         },
+	//         "Dir": "/home/gongyuan_kubeflow_org/go/pkg/mod/k8s.io/kubernetes@v1.11.1",
+	//         "GoMod": "/home/gongyuan_kubeflow_org/go/pkg/mod/cache/download/k8s.io/kubernetes/@v/v1.11.1.mod"
+	// }
+	// handle replace directives
+	// Note, we specifically want to replace version field.
+	// Haven't confirmed, but we may also need to override the
+	// entire struct when using replace directive with local folders.
+	tmp := *mod
+	if tmp.Replace != nil {
+		tmp = *tmp.Replace
+	}
+	// The +incompatible suffix does not affect module version.
+	// ref: https://golang.org/ref/mod#incompatible-versions
+	tmp.Version = strings.TrimSuffix(tmp.Version, "+incompatible")
+	return &Module{
+		Path:    tmp.Path,
+		Version: tmp.Version,
+		Dir:     tmp.Dir,
+	}
+}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,8 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/golang/glog"
@@ -32,6 +34,19 @@ var (
 )
 
 func init() {
+	// Change glog default log level to INFO.
+	// Note glog is not initialized yet, so we can only use fmt for printing
+	// errors.
+	err := flag.Set("logtostderr", "true")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	err = flag.Set("stderrthreshold", "INFO")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 	rootCmd.PersistentFlags().Float64Var(&confidenceThreshold, "confidence_threshold", 0.9, "Minimum confidence required in order to positively identify a license.")
 }
 

--- a/testdata/modules/cli02/licenses.csv
+++ b/testdata/modules/cli02/licenses.csv
@@ -1,18 +1,18 @@
-github.com/fsnotify/fsnotify,https://github.com/fsnotify/fsnotify/blob/master/LICENSE,BSD-3-Clause
-github.com/google/go-licenses/testdata/modules/cli02,https://github.com/google/go-licenses/blob/master/testdata/modules/cli02/LICENSE,Apache-2.0
-github.com/hashicorp/hcl,https://github.com/hashicorp/hcl/blob/master/LICENSE,MPL-2.0
-github.com/magiconair/properties,https://github.com/magiconair/properties/blob/master/LICENSE.md,BSD-2-Clause
-github.com/mitchellh/go-homedir,https://github.com/mitchellh/go-homedir/blob/master/LICENSE,MIT
-github.com/mitchellh/mapstructure,https://github.com/mitchellh/mapstructure/blob/master/LICENSE,MIT
-github.com/pelletier/go-toml,https://github.com/pelletier/go-toml/blob/master/LICENSE,Apache-2.0
-github.com/spf13/afero,https://github.com/spf13/afero/blob/master/LICENSE.txt,Apache-2.0
-github.com/spf13/cast,https://github.com/spf13/cast/blob/master/LICENSE,MIT
-github.com/spf13/cobra,https://github.com/spf13/cobra/blob/master/LICENSE.txt,Apache-2.0
-github.com/spf13/jwalterweatherman,https://github.com/spf13/jwalterweatherman/blob/master/LICENSE,MIT
-github.com/spf13/pflag,https://github.com/spf13/pflag/blob/master/LICENSE,BSD-3-Clause
-github.com/spf13/viper,https://github.com/spf13/viper/blob/master/LICENSE,MIT
-github.com/subosito/gotenv,https://github.com/subosito/gotenv/blob/master/LICENSE,MIT
-golang.org/x/sys,Unknown,BSD-3-Clause
-golang.org/x/text,Unknown,BSD-3-Clause
-gopkg.in/ini.v1,Unknown,Apache-2.0
-gopkg.in/yaml.v2,Unknown,Apache-2.0
+github.com/fsnotify/fsnotify, https://github.com/fsnotify/fsnotify/blob/v1.4.9/LICENSE, BSD-3-Clause
+github.com/google/go-licenses/testdata/modules/cli02, https://github.com/google/go-licenses/blob/testdata/modules/cli02/master/testdata/modules/cli02/LICENSE, Apache-2.0
+github.com/hashicorp/hcl, https://github.com/hashicorp/hcl/blob/v1.0.0/LICENSE, MPL-2.0
+github.com/magiconair/properties, https://github.com/magiconair/properties/blob/v1.8.5/LICENSE.md, BSD-2-Clause
+github.com/mitchellh/go-homedir, https://github.com/mitchellh/go-homedir/blob/v1.1.0/LICENSE, MIT
+github.com/mitchellh/mapstructure, https://github.com/mitchellh/mapstructure/blob/v1.4.1/LICENSE, MIT
+github.com/pelletier/go-toml, https://github.com/pelletier/go-toml/blob/v1.9.3/LICENSE, Apache-2.0
+github.com/spf13/afero, https://github.com/spf13/afero/blob/v1.6.0/LICENSE.txt, Apache-2.0
+github.com/spf13/cast, https://github.com/spf13/cast/blob/v1.3.1/LICENSE, MIT
+github.com/spf13/cobra, https://github.com/spf13/cobra/blob/v1.1.3/LICENSE.txt, Apache-2.0
+github.com/spf13/jwalterweatherman, https://github.com/spf13/jwalterweatherman/blob/v1.1.0/LICENSE, MIT
+github.com/spf13/pflag, https://github.com/spf13/pflag/blob/v1.0.5/LICENSE, BSD-3-Clause
+github.com/spf13/viper, https://github.com/spf13/viper/blob/v1.8.0/LICENSE, MIT
+github.com/subosito/gotenv, https://github.com/subosito/gotenv/blob/v1.2.0/LICENSE, MIT
+golang.org/x/sys, https://cs.opensource.google/go/x/sys/+/977fb726:LICENSE, BSD-3-Clause
+golang.org/x/text, https://cs.opensource.google/go/x/text/+/v0.3.5:LICENSE, BSD-3-Clause
+gopkg.in/ini.v1, https://github.com/go-ini/ini/blob/v1.62.0/LICENSE, Apache-2.0
+gopkg.in/yaml.v2, https://github.com/go-yaml/yaml/blob/v2.4.0/LICENSE, Apache-2.0

--- a/testdata/modules/cli02/licenses.csv
+++ b/testdata/modules/cli02/licenses.csv
@@ -1,5 +1,5 @@
 github.com/fsnotify/fsnotify, https://github.com/fsnotify/fsnotify/blob/v1.4.9/LICENSE, BSD-3-Clause
-github.com/google/go-licenses/testdata/modules/cli02, https://github.com/google/go-licenses/blob/testdata/modules/cli02/master/testdata/modules/cli02/LICENSE, Apache-2.0
+github.com/google/go-licenses/testdata/modules/cli02, https://github.com/google/go-licenses/blob/HEAD/testdata/modules/cli02/LICENSE, Apache-2.0
 github.com/hashicorp/hcl, https://github.com/hashicorp/hcl/blob/v1.0.0/LICENSE, MPL-2.0
 github.com/magiconair/properties, https://github.com/magiconair/properties/blob/v1.8.5/LICENSE.md, BSD-2-Clause
 github.com/mitchellh/go-homedir, https://github.com/mitchellh/go-homedir/blob/v1.1.0/LICENSE, MIT

--- a/testdata/modules/cli02/licenses.csv
+++ b/testdata/modules/cli02/licenses.csv
@@ -1,18 +1,18 @@
-github.com/fsnotify/fsnotify, https://github.com/fsnotify/fsnotify/blob/v1.4.9/LICENSE, BSD-3-Clause
-github.com/google/go-licenses/testdata/modules/cli02, https://github.com/google/go-licenses/blob/HEAD/testdata/modules/cli02/LICENSE, Apache-2.0
-github.com/hashicorp/hcl, https://github.com/hashicorp/hcl/blob/v1.0.0/LICENSE, MPL-2.0
-github.com/magiconair/properties, https://github.com/magiconair/properties/blob/v1.8.5/LICENSE.md, BSD-2-Clause
-github.com/mitchellh/go-homedir, https://github.com/mitchellh/go-homedir/blob/v1.1.0/LICENSE, MIT
-github.com/mitchellh/mapstructure, https://github.com/mitchellh/mapstructure/blob/v1.4.1/LICENSE, MIT
-github.com/pelletier/go-toml, https://github.com/pelletier/go-toml/blob/v1.9.3/LICENSE, Apache-2.0
-github.com/spf13/afero, https://github.com/spf13/afero/blob/v1.6.0/LICENSE.txt, Apache-2.0
-github.com/spf13/cast, https://github.com/spf13/cast/blob/v1.3.1/LICENSE, MIT
-github.com/spf13/cobra, https://github.com/spf13/cobra/blob/v1.1.3/LICENSE.txt, Apache-2.0
-github.com/spf13/jwalterweatherman, https://github.com/spf13/jwalterweatherman/blob/v1.1.0/LICENSE, MIT
-github.com/spf13/pflag, https://github.com/spf13/pflag/blob/v1.0.5/LICENSE, BSD-3-Clause
-github.com/spf13/viper, https://github.com/spf13/viper/blob/v1.8.0/LICENSE, MIT
-github.com/subosito/gotenv, https://github.com/subosito/gotenv/blob/v1.2.0/LICENSE, MIT
-golang.org/x/sys, https://cs.opensource.google/go/x/sys/+/977fb726:LICENSE, BSD-3-Clause
-golang.org/x/text, https://cs.opensource.google/go/x/text/+/v0.3.5:LICENSE, BSD-3-Clause
-gopkg.in/ini.v1, https://github.com/go-ini/ini/blob/v1.62.0/LICENSE, Apache-2.0
-gopkg.in/yaml.v2, https://github.com/go-yaml/yaml/blob/v2.4.0/LICENSE, Apache-2.0
+github.com/fsnotify/fsnotify,https://github.com/fsnotify/fsnotify/blob/v1.4.9/LICENSE,BSD-3-Clause
+github.com/google/go-licenses/testdata/modules/cli02,https://github.com/google/go-licenses/blob/HEAD/testdata/modules/cli02/LICENSE,Apache-2.0
+github.com/hashicorp/hcl,https://github.com/hashicorp/hcl/blob/v1.0.0/LICENSE,MPL-2.0
+github.com/magiconair/properties,https://github.com/magiconair/properties/blob/v1.8.5/LICENSE.md,BSD-2-Clause
+github.com/mitchellh/go-homedir,https://github.com/mitchellh/go-homedir/blob/v1.1.0/LICENSE,MIT
+github.com/mitchellh/mapstructure,https://github.com/mitchellh/mapstructure/blob/v1.4.1/LICENSE,MIT
+github.com/pelletier/go-toml,https://github.com/pelletier/go-toml/blob/v1.9.3/LICENSE,Apache-2.0
+github.com/spf13/afero,https://github.com/spf13/afero/blob/v1.6.0/LICENSE.txt,Apache-2.0
+github.com/spf13/cast,https://github.com/spf13/cast/blob/v1.3.1/LICENSE,MIT
+github.com/spf13/cobra,https://github.com/spf13/cobra/blob/v1.1.3/LICENSE.txt,Apache-2.0
+github.com/spf13/jwalterweatherman,https://github.com/spf13/jwalterweatherman/blob/v1.1.0/LICENSE,MIT
+github.com/spf13/pflag,https://github.com/spf13/pflag/blob/v1.0.5/LICENSE,BSD-3-Clause
+github.com/spf13/viper,https://github.com/spf13/viper/blob/v1.8.0/LICENSE,MIT
+github.com/subosito/gotenv,https://github.com/subosito/gotenv/blob/v1.2.0/LICENSE,MIT
+golang.org/x/sys,https://cs.opensource.google/go/x/sys/+/977fb726:LICENSE,BSD-3-Clause
+golang.org/x/text,https://cs.opensource.google/go/x/text/+/v0.3.5:LICENSE,BSD-3-Clause
+gopkg.in/ini.v1,https://github.com/go-ini/ini/blob/v1.62.0/LICENSE,Apache-2.0
+gopkg.in/yaml.v2,https://github.com/go-yaml/yaml/blob/v2.4.0/LICENSE,Apache-2.0

--- a/testdata/modules/hello01/licenses.csv
+++ b/testdata/modules/hello01/licenses.csv
@@ -1,1 +1,1 @@
-github.com/google/go-licenses/testdata/modules/hello01, https://github.com/google/go-licenses/blob/HEAD/testdata/modules/hello01/LICENSE, Apache-2.0
+github.com/google/go-licenses/testdata/modules/hello01,https://github.com/google/go-licenses/blob/HEAD/testdata/modules/hello01/LICENSE,Apache-2.0

--- a/testdata/modules/hello01/licenses.csv
+++ b/testdata/modules/hello01/licenses.csv
@@ -1,1 +1,1 @@
-github.com/google/go-licenses/testdata/modules/hello01,https://github.com/google/go-licenses/blob/master/testdata/modules/hello01/LICENSE,Apache-2.0
+github.com/google/go-licenses/testdata/modules/hello01, https://github.com/google/go-licenses/blob/testdata/modules/hello01/master/testdata/modules/hello01/LICENSE, Apache-2.0

--- a/testdata/modules/hello01/licenses.csv
+++ b/testdata/modules/hello01/licenses.csv
@@ -1,1 +1,1 @@
-github.com/google/go-licenses/testdata/modules/hello01, https://github.com/google/go-licenses/blob/testdata/modules/hello01/master/testdata/modules/hello01/LICENSE, Apache-2.0
+github.com/google/go-licenses/testdata/modules/hello01, https://github.com/google/go-licenses/blob/HEAD/testdata/modules/hello01/LICENSE, Apache-2.0

--- a/testdata/modules/replace04/licenses.csv
+++ b/testdata/modules/replace04/licenses.csv
@@ -1,2 +1,2 @@
-github.com/google/go-licenses/testdata/modules/replace04, https://github.com/google/go-licenses/blob/HEAD/testdata/modules/replace04/LICENSE, Apache-2.0
-github.com/mitchellh/go-homedir, https://github.com/mitchellh/go-homedir/blob/v1.0.0/LICENSE, MIT
+github.com/google/go-licenses/testdata/modules/replace04,https://github.com/google/go-licenses/blob/HEAD/testdata/modules/replace04/LICENSE,Apache-2.0
+github.com/mitchellh/go-homedir,https://github.com/mitchellh/go-homedir/blob/v1.0.0/LICENSE,MIT

--- a/testdata/modules/replace04/licenses.csv
+++ b/testdata/modules/replace04/licenses.csv
@@ -1,2 +1,2 @@
-github.com/google/go-licenses/testdata/modules/replace04,https://github.com/google/go-licenses/blob/master/testdata/modules/replace04/LICENSE,Apache-2.0
-github.com/mitchellh/go-homedir,https://github.com/mitchellh/go-homedir/blob/master/LICENSE,MIT
+github.com/google/go-licenses/testdata/modules/replace04, https://github.com/google/go-licenses/blob/testdata/modules/replace04/master/testdata/modules/replace04/LICENSE, Apache-2.0
+github.com/mitchellh/go-homedir, https://github.com/mitchellh/go-homedir/blob/v1.1.0/LICENSE, MIT

--- a/testdata/modules/replace04/licenses.csv
+++ b/testdata/modules/replace04/licenses.csv
@@ -1,2 +1,2 @@
 github.com/google/go-licenses/testdata/modules/replace04, https://github.com/google/go-licenses/blob/HEAD/testdata/modules/replace04/LICENSE, Apache-2.0
-github.com/mitchellh/go-homedir, https://github.com/mitchellh/go-homedir/blob/v1.1.0/LICENSE, MIT
+github.com/mitchellh/go-homedir, https://github.com/mitchellh/go-homedir/blob/v1.0.0/LICENSE, MIT

--- a/testdata/modules/replace04/licenses.csv
+++ b/testdata/modules/replace04/licenses.csv
@@ -1,2 +1,2 @@
-github.com/google/go-licenses/testdata/modules/replace04, https://github.com/google/go-licenses/blob/testdata/modules/replace04/master/testdata/modules/replace04/LICENSE, Apache-2.0
+github.com/google/go-licenses/testdata/modules/replace04, https://github.com/google/go-licenses/blob/HEAD/testdata/modules/replace04/LICENSE, Apache-2.0
 github.com/mitchellh/go-homedir, https://github.com/mitchellh/go-homedir/blob/v1.1.0/LICENSE, MIT

--- a/testdata/modules/vendored03/licenses.csv
+++ b/testdata/modules/vendored03/licenses.csv
@@ -1,2 +1,2 @@
-github.com/google/go-licenses/testdata/modules/vendored03, https://github.com/google/go-licenses/blob/testdata/modules/vendored03/master/testdata/modules/vendored03/LICENSE, Apache-2.0
-github.com/mitchellh/go-homedir, Unknown, MIT
+github.com/google/go-licenses/testdata/modules/vendored03, https://github.com/google/go-licenses/blob/HEAD/testdata/modules/vendored03/LICENSE, Apache-2.0
+github.com/mitchellh/go-homedir, https://github.com/google/go-licenses/blob/HEAD/testdata/modules/vendored03/vendor/github.com/mitchellh/go-homedir/LICENSE, MIT

--- a/testdata/modules/vendored03/licenses.csv
+++ b/testdata/modules/vendored03/licenses.csv
@@ -1,2 +1,2 @@
-github.com/google/go-licenses/testdata/modules/vendored03, https://github.com/google/go-licenses/blob/HEAD/testdata/modules/vendored03/LICENSE, Apache-2.0
-github.com/mitchellh/go-homedir, https://github.com/google/go-licenses/blob/HEAD/testdata/modules/vendored03/vendor/github.com/mitchellh/go-homedir/LICENSE, MIT
+github.com/google/go-licenses/testdata/modules/vendored03,https://github.com/google/go-licenses/blob/HEAD/testdata/modules/vendored03/LICENSE,Apache-2.0
+github.com/mitchellh/go-homedir,https://github.com/google/go-licenses/blob/HEAD/testdata/modules/vendored03/vendor/github.com/mitchellh/go-homedir/LICENSE,MIT

--- a/testdata/modules/vendored03/licenses.csv
+++ b/testdata/modules/vendored03/licenses.csv
@@ -1,2 +1,2 @@
-github.com/google/go-licenses/testdata/modules/vendored03,https://github.com/google/go-licenses/blob/master/testdata/modules/vendored03/LICENSE,Apache-2.0
-github.com/mitchellh/go-homedir,https://github.com/google/go-licenses/blob/master/testdata/modules/vendored03/vendor/github.com/mitchellh/go-homedir/LICENSE,MIT
+github.com/google/go-licenses/testdata/modules/vendored03, https://github.com/google/go-licenses/blob/testdata/modules/vendored03/master/testdata/modules/vendored03/LICENSE, Apache-2.0
+github.com/mitchellh/go-homedir, Unknown, MIT


### PR DESCRIPTION
BREAKING CHANGE: this tool no longer natively supports go projects managed by GOPATH. It only works with go modules projects now.

Changes:
* Use module dir as find license upper boundary.
* Use pkgsite/source and module version to find package remote URL, part of #73 
* Handles the case when main module vendors its deps
* Handles the case a replace directive is used