### PR TITLE
Use golang:1.18 as base image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13 as build
+FROM golang:1.18 as build
 
 WORKDIR /go-licenses
 


### PR DESCRIPTION
Source code uses embed but 1.13 does not have it.