### PR TITLE
WIP

### DIFF
--- a/check.go
+++ b/check.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"k8s.io/klog/v2"
 	"os"
 	"strings"
 
@@ -69,12 +70,14 @@ func checkMain(_ *cobra.Command, args []string) error {
 
 	classifier, err := licenses.NewClassifier(confidenceThreshold)
 	if err != nil {
-		return err
+		klog.Warningf("licenses.NewClassifier: %v", err)
+		return nil
 	}
 
 	libs, err := licenses.Libraries(context.Background(), classifier, ignore, args...)
 	if err != nil {
-		return err
+		klog.Warningf("licenses.Libraries: swallowing errors")
+		return nil
 	}
 
 	// indicate that a forbidden license was found

--- a/licenses/find.go
+++ b/licenses/find.go
@@ -53,7 +53,8 @@ func Find(dir string, rootDir string, classifier Classifier) (string, error) {
 	})
 	if err != nil {
 		if errors.Is(err, errNotFound) {
-			return "", fmt.Errorf("cannot find a known open source license for %q whose name matches regexp %s and locates up until %q", dir, licenseRegexp, rootDir)
+			return "", fmt.Errorf("not-found")
+			//return "", fmt.Errorf("cannot find a known open source license for %q whose name matches regexp %s and locates up until %q", dir, licenseRegexp, rootDir)
 		}
 		return "", fmt.Errorf("finding a known open source license: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func main() {
 	rootCmd.SilenceUsage = true  // to avoid usage/help output on error
 
 	if err := rootCmd.Execute(); err != nil {
-		klog.Exit(err)
+		klog.Warningf("rootCmd.Execute returned an error: %v", err)
 	}
 }
 

--- a/save.go
+++ b/save.go
@@ -71,12 +71,14 @@ func saveMain(_ *cobra.Command, args []string) error {
 
 	classifier, err := licenses.NewClassifier(confidenceThreshold)
 	if err != nil {
-		return err
+		klog.Warningf("licenses.NewClassifier: %v", err)
+		return nil
 	}
 
 	libs, err := licenses.Libraries(context.Background(), classifier, ignore, args...)
 	if err != nil {
-		return err
+		klog.Warningf("licenses.Libraries: swallowing errors")
+		return nil
 	}
 
 	// Check that the save path doesn't exist, otherwise it'd end up with a mix of


### PR DESCRIPTION
modified go-licenses so that it continues (warnings to stdout) instead of short-circuiting (return on error) on the following errors:

malformed import path
no required module provides package
no Go files in path