### PR TITLE
Add include_tests flag for deps only used in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,14 +279,11 @@ This flag makes effect to `check`, `report` and `save` commands.
 
 ### Include testing packages
 
-Use the `--include_tests` global flag to include packages only imported by testing code.
-For example, those packages could be testing libraries/frameworks.
-Usually you would want to add this flag because if you're already analyzing the licenses of your dependencies,
-likely those packages also need to be taken into account.
+Use the `--include_tests` global flag to include packages only imported by testing code (e.g., testing libraries/frameworks).
 Example command:
 
 ```shell
-go-licenses check --include_tests "github.com/google/go-licenses"
+go-licenses check --include_tests "github.com/google/go-licenses/..."
 ```
 
 This flag makes effect to `check`, `report` and `save` commands.

--- a/README.md
+++ b/README.md
@@ -277,6 +277,20 @@ $ go-licenses check \
 Note that dependencies from the ignored packages are still resolved and checked.
 This flag makes effect to `check`, `report` and `save` commands.
 
+### Include testing packages
+
+Use the `--include_tests` global flag to include packages only imported by testing code.
+For example, those packages could be testing libraries/frameworks.
+Usually you would want to add this flag because if you're already analyzing the licenses of your dependencies,
+likely those packages also need to be taken into account.
+Example command:
+
+```shell
+go-licenses check --include_tests "github.com/google/go-licenses"
+```
+
+This flag makes effect to `check`, `report` and `save` commands.
+
 ## Warnings and errors
 
 The tool will log warnings and errors in some scenarios. This section provides

--- a/check.go
+++ b/check.go
@@ -72,7 +72,7 @@ func checkMain(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	libs, err := licenses.Libraries(context.Background(), classifier, ignore, args...)
+	libs, err := licenses.Libraries(context.Background(), classifier, includeTests, ignore, args...)
 	if err != nil {
 		return err
 	}

--- a/licenses/library_test.go
+++ b/licenses/library_test.go
@@ -38,11 +38,12 @@ func TestLibraries(t *testing.T) {
 	}
 
 	for _, test := range []struct {
-		desc       string
-		importPath string
-		goflags    string
-		ignore     []string
-		wantLibs   []string
+		desc         string
+		importPath   string
+		goflags      string
+		includeTests bool
+		ignore       []string
+		wantLibs     []string
 	}{
 		{
 			desc:       "Detects direct dependency",
@@ -73,6 +74,24 @@ func TestLibraries(t *testing.T) {
 			},
 		},
 		{
+			desc:         "Detects the dependencies only imported in testing code",
+			importPath:   "github.com/google/go-licenses/licenses/testdata/testlib",
+			includeTests: true,
+			wantLibs: []string{
+				"github.com/google/go-licenses/licenses/testdata/testlib",
+				"github.com/google/go-licenses/licenses/testdata/testlib.test",
+				"github.com/google/go-licenses/licenses/testdata/indirect",
+			},
+		},
+		{
+			desc:         "Should not detect the dependencies only imported in testing code",
+			importPath:   "github.com/google/go-licenses/licenses/testdata/testlib",
+			includeTests: false,
+			wantLibs: []string{
+				"github.com/google/go-licenses/licenses/testdata/testlib",
+			},
+		},
+		{
 			desc:       "Build tagged package",
 			importPath: "github.com/google/go-licenses/licenses/testdata/tags",
 			goflags:    "-tags=tags",
@@ -87,7 +106,7 @@ func TestLibraries(t *testing.T) {
 				os.Setenv("GOFLAGS", test.goflags)
 				defer os.Unsetenv("GOFLAGS")
 			}
-			gotLibs, err := Libraries(context.Background(), classifier, test.ignore, test.importPath)
+			gotLibs, err := Libraries(context.Background(), classifier, test.includeTests, test.ignore, test.importPath)
 			if err != nil {
 				t.Fatalf("Libraries(_, %q) = (_, %q), want (_, nil)", test.importPath, err)
 			}

--- a/licenses/library_test.go
+++ b/licenses/library_test.go
@@ -79,7 +79,6 @@ func TestLibraries(t *testing.T) {
 			includeTests: true,
 			wantLibs: []string{
 				"github.com/google/go-licenses/licenses/testdata/testlib",
-				"github.com/google/go-licenses/licenses/testdata/testlib.test",
 				"github.com/google/go-licenses/licenses/testdata/indirect",
 			},
 		},

--- a/licenses/testdata/testlib/testlib.go
+++ b/licenses/testdata/testlib/testlib.go
@@ -1,0 +1,15 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testlib

--- a/licenses/testdata/testlib/testlib_test.go
+++ b/licenses/testdata/testlib/testlib_test.go
@@ -1,0 +1,20 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testlib
+
+import (
+	// This import should be detected if includeTests set true
+	_ "github.com/google/go-licenses/licenses/testdata/indirect"
+)

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ Prerequisites:
 
 	// Flags shared between subcommands
 	confidenceThreshold float64
+	includeTests        bool
 	ignore              []string
 	packageHelp         = `
 
@@ -62,6 +63,7 @@ func init() {
 		os.Exit(1)
 	}
 	rootCmd.PersistentFlags().Float64Var(&confidenceThreshold, "confidence_threshold", 0.9, "Minimum confidence required in order to positively identify a license.")
+	rootCmd.PersistentFlags().BoolVar(&includeTests, "include_tests", false, "Include packages only imported by testing code.")
 	rootCmd.PersistentFlags().StringSliceVar(&ignore, "ignore", nil, "Package path prefixes to be ignored. Dependencies from the ignored packages are still checked. Can be specified multiple times.")
 }
 

--- a/report.go
+++ b/report.go
@@ -61,7 +61,7 @@ func reportMain(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	libs, err := licenses.Libraries(context.Background(), classifier, ignore, args...)
+	libs, err := licenses.Libraries(context.Background(), classifier, includeTests, ignore, args...)
 	if err != nil {
 		return err
 	}

--- a/save.go
+++ b/save.go
@@ -74,7 +74,7 @@ func saveMain(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	libs, err := licenses.Libraries(context.Background(), classifier, ignore, args...)
+	libs, err := licenses.Libraries(context.Background(), classifier, includeTests, ignore, args...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
PR fixes #62. PR is based on the [work](https://github.com/blanet/go-licenses/commit/5cef818b1ddbf4ac843e41ac0745ad3c4ca02633) of @blanet.