### PR TITLE
Provide an example for check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,10 +221,10 @@ Checking for forbidden and unknown licenses usage:
 go-licenses check <package> [package...]
 ```
 
-**Tip**: Usually you'll want to add
+**Tip**: Usually you'll want to
 
-* `...` to check all the packages in your repository
-* `--include_tests` to also check packages only imported by testing code (e.g., testing libraries/frameworks)
+* append `/...` to the end of an import path prefix (e.g., your repo path) to include all packages matching that pattern
+* add `--include_tests` to also check packages only imported by testing code (e.g., testing libraries/frameworks)
 
 ```shell
 go-licenses check --include_tests github.com/google/go-licenses/...

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ go-licenses check <package> [package...]
 * `--include_tests` to also check packages only imported by testing code (e.g., testing libraries/frameworks)
 
 ```shell
-go-licenses check --include_tests github.com/your-org/your-repo/...
+go-licenses check --include_tests github.com/google/go-licenses/...
 ```
 
 Checking for disallowed license types:

--- a/README.md
+++ b/README.md
@@ -218,7 +218,16 @@ go-licenses save <package> [package...] --save_path=<save_path>
 Checking for forbidden and unknown licenses usage:
 
 ```shell
-go-licenses check <package> [package...] 
+go-licenses check <package> [package...]
+```
+
+**Tip**: Usually you'll want to add
+
+* `...` to check all the packages in your repository
+* `--include_tests` to also check packages only imported by testing code (e.g., testing libraries/frameworks)
+
+```shell
+go-licenses check --include_tests github.com/your-org/your-repo/...
 ```
 
 Checking for disallowed license types:
@@ -228,6 +237,7 @@ go-licenses check <package> [package...] --disallowed_types=<comma separated lic
 ```
 
 Supported license types:
+
 * See `forbidden` list: [github.com/google/licenseclassifier](https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L341)
 * See `notice` list:  [github.com/google/licenseclassifier](https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L249)
 * See `permissive` list:  [github.com/google/licenseclassifier](https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L321)
@@ -242,7 +252,7 @@ Allow only specific license names:
 go-licenses check <package> [package...] --allowed_licenses=<comma separated license names> 
 ```
 
-* See supported license names: [github.com/google/licenseclassifier](https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L28)  
+* See supported license names: [github.com/google/licenseclassifier](https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L28)
 
 ### Build tags
 


### PR DESCRIPTION
## Summary

PR fixes https://github.com/google/go-licenses/pull/160#discussion_r1002744147.

## Notes

- The usage of `**Tip**` comes from https://github.com/google/go-licenses/blob/6073243b8a005f776321958637a2d1e796e05ce5/README.md?plain=1#L86
-  `--include_test` is also added because that's the very reason why I created #160, and https://github.com/google/go-licenses/pull/160#discussion_r1002734812 also mentions:

    > I would use the flag when running check, because all deps must be allowed.

- I thought about putting this section after those of the flags (e.g., `--disallowed_types`), but I feel that `go-licenses check --include_tests github.com/your-org/your-repo/...` is potentially a template command that suits most use cases (i.e., users only need to replace the placeholders to make the command work for them), so I put it right after the intro of `check`. No strong opinion though.