### PR TITLE
adds license and shortname to reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,11 @@ data:
 ```go
 []struct {
   Name        string
-  Version     string
+  ShortName   string
   LicenseURL  string
   LicenseName string
+  Version     string
+  License     string
 }
 ```
 
@@ -181,6 +183,7 @@ for licenses considered forbidden.
 ## Usages
 
 ### Global
+
 Typically, specify the Go package that builds your Go binary.
 go-licenses expects the same package argument format as `go build`.  For examples:
 


### PR DESCRIPTION
# Description

This PR adds the fields ShortName (removes github.com from LibName) and adds the License, so it can be generated into a report by using the appropriate template.
