### PR TITLE
Fix vendored build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,27 +1,50 @@
 module github.com/google/go-licenses
 
-go 1.16
+go 1.17
 
 require (
-	cloud.google.com/go/iam v0.4.0 // indirect
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-cmp v0.5.8
 	github.com/google/go-replayers/httpreplay v1.1.1
 	github.com/google/licenseclassifier v0.0.0-20210722185704-3043a050f148
-	github.com/kr/text v0.2.0 // indirect
-	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/otiai10/copy v1.6.0
-	github.com/pkg/errors v0.9.1 // indirect
-	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/spf13/cobra v1.6.0
-	github.com/stretchr/testify v1.8.0 // indirect
 	go.opencensus.io v0.23.0
-	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/mod v0.9.0
 	golang.org/x/net v0.5.0
 	golang.org/x/text v0.6.0
 	golang.org/x/tools v0.5.0
-	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	k8s.io/klog/v2 v2.80.1
+)
+
+require (
+	cloud.google.com/go v0.102.1 // indirect
+	cloud.google.com/go/iam v0.4.0 // indirect
+	cloud.google.com/go/storage v1.22.1 // indirect
+	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/go-logr/logr v1.2.0 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/google/martian/v3 v3.3.2 // indirect
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/src-d/gcfg v1.4.0 // indirect
+	github.com/stretchr/testify v1.8.0 // indirect
+	github.com/xanzy/ssh-agent v0.2.1 // indirect
+	golang.org/x/crypto v0.1.0 // indirect
+	golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2 // indirect
+	golang.org/x/sys v0.4.0 // indirect
+	google.golang.org/api v0.93.0 // indirect
+	google.golang.org/genproto v0.0.0-20220815135757-37a418bb8959 // indirect
+	google.golang.org/grpc v1.48.0 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
+	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
+	gopkg.in/src-d/go-billy.v4 v4.3.2 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
 )


### PR DESCRIPTION
Before when running go mod vendor and then go build the following error would be produced:

$ go build ./...
vendor/golang.org/x/sys/unix/syscall.go:83:16: unsafe.Slice requires go1.17 or later (-lang was set to go1.16; check go.mod) vendor/golang.org/x/sys/unix/syscall_linux.go:2270:9: unsafe.Slice requires go1.17 or later (-lang was set to go1.16; check go.mod) vendor/golang.org/x/sys/unix/syscall_unix.go:118:7: unsafe.Slice requires go1.17 or later (-lang was set to go1.16; check go.mod) vendor/golang.org/x/sys/unix/sysvshm_unix.go:33:7: unsafe.Slice requires go1.17 or later (-lang was set to go1.16; check go.mod)

This is fixed by bumping the minimal go version and then running go mod tidy