### PR TITLE
If the same license is found in a LICENSE file twice, only return it once

### DIFF
--- a/licenses/classifier.go
+++ b/licenses/classifier.go
@@ -63,11 +63,19 @@ func (c *googleClassifier) Identify(licensePath string) ([]License, error) {
 		return nil, err
 	}
 
+	foundLicenseNames := map[string]struct{}{}
+
 	licenses := []License{}
 	for _, match := range matches.Matches {
 		if match.MatchType != "License" {
 			continue
 		}
+
+		// Skip duplicate licenses.
+		if _, ok := foundLicenseNames[match.Name]; ok {
+			continue
+		}
+		foundLicenseNames[match.Name] = struct{}{}
 
 		licenses = append(licenses, License{
 			Name: match.Name,


### PR DESCRIPTION
If the same license is found in a LICENSE file twice, only return it once.