### PR TITLE
fix: problem detecting stdlib modules when using toolchains

### DIFF
--- a/licenses/library.go
+++ b/licenses/library.go
@@ -154,12 +154,6 @@ func Libraries(ctx context.Context, classifier Classifier, includeTests bool, ig
 				return true
 			}
 
-			if p.Module == nil {
-				otherErrorOccurred = true
-				klog.Errorf("Package %s does not have module info. Non go modules projects are no longer supported. For feedback, refer to https://github.com/google/go-licenses/issues/128.", p.PkgPath)
-				return false
-			}
-
 			module := newModule(p.Module)
 
 			if module.Dir == "" {
@@ -411,6 +405,10 @@ func (l *Library) Version() string {
 
 // isStdLib returns true if this package is part of the Go standard library.
 func isStdLib(pkg *packages.Package) bool {
+	if pkg.Module == nil {
+		return true
+	}
+
 	if pkg.Name == "unsafe" {
 		// Special case unsafe stdlib, because it does not contain go files.
 		return true


### PR DESCRIPTION
If the pkg.Module is `nil`, it's either part of the stdlib or it's not something that go-licenses can analyze correctly. Let's just skip modules like this instead of reporting an error.

The problem with the existing check is that it assumes that stdlib packages will have source files under `build.Default.GOROOT`. But if the module you're trying to analyze has a `toolchain` directive in its go.mod file that differs from the version of Go installed, the package will have a path outside of this directory.

I _think_ we could possibly also remove the code that checks for a specific prefix based off the GOROOT, but I wasn't 100% sure of that so I've left it in for now. I figure it doesn't do any harm (other than add a bit of confusion for future potentially).

Reproducing the problem is pretty simple:

1. Install some version of Go (e.g. 1.24.1).
2. Create a project with a `toolchain <go-version>` directive in the go.mod file where that version is different to your installed Go version (e.g. 1.24.2).
3. Try to run go-licenses.

The crossplane project referenced in #302 actually has an example of this in their [go.mod](https://github.com/crossplane/crossplane/blob/0b8bfcb49859843772669528b6c59e909635b0b9/go.mod#L5) file (presumably the cause of the problem).

I think this should resolve the following issues:

- #128 (at least some of the causes).
- #244.
- #302.
- #324.